### PR TITLE
Fix grant/revoke errors for some kinds of grants.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,10 +47,10 @@ jobs:
       BATON_BITBUCKETDC_USERNAME: ${{ secrets.BATON_BITBUCKETDC_USERNAME }}
       BATON_BITBUCKETDC_PASSWORD: ${{ secrets.BATON_BITBUCKETDC_PASSWORD }}
       # The following parameters are passed to grant/revoke commands
-      CONNECTOR_GRANT: 'group:local-group:member:user:62'
+      CONNECTOR_GRANT: 'group:local-group:member:user:f1'
       CONNECTOR_ENTITLEMENT: 'group:local-group:member'
       CONNECTOR_PRINCIPAL_TYPE: 'user'
-      CONNECTOR_PRINCIPAL: '62'
+      CONNECTOR_PRINCIPAL: 'f1'
     steps:
       - name: Install Go
         uses: actions/setup-go@v4

--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"slices"
-	"strconv"
 
 	"github.com/conductorone/baton-bitbucket-datacenter/pkg/client"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
@@ -130,11 +129,7 @@ func (g *groupBuilder) Grant(ctx context.Context, principal *v2.Resource, entitl
 	groupName := entitlement.Resource.Id.Resource
 	switch principal.Id.ResourceType {
 	case resourceTypeUser.Id:
-		userName := principal.DisplayName
-		userId, err := strconv.Atoi(principal.Id.Resource)
-		if err != nil {
-			return nil, err
-		}
+		userName := principal.Id.Resource
 
 		// Check if user is already a member of the group
 		listGroups, err := listGroupMembers(ctx, g.client, groupName)
@@ -143,7 +138,7 @@ func (g *groupBuilder) Grant(ctx context.Context, principal *v2.Resource, entitl
 		}
 
 		groupPos := slices.IndexFunc(listGroups, func(c client.Members) bool {
-			return c.ID == userId
+			return c.Name == userName
 		})
 		if groupPos >= 0 {
 			l.Info(
@@ -161,7 +156,6 @@ func (g *groupBuilder) Grant(ctx context.Context, principal *v2.Resource, entitl
 		}
 
 		l.Info("Group membership granted.",
-			zap.Int64("UserID", int64(userId)),
 			zap.String("User", userName),
 			zap.String("Group", groupName),
 		)
@@ -194,11 +188,8 @@ func (g *groupBuilder) Revoke(ctx context.Context, grant *v2.Grant) (annotations
 	groupName := groupResourceId.Resource
 	switch principal.Id.ResourceType {
 	case resourceTypeUser.Id:
-		userName := principal.DisplayName
-		userId, err := strconv.Atoi(principal.Id.Resource)
-		if err != nil {
-			return nil, err
-		}
+		userName := principal.Id.Resource
+
 		// Check if user is member of the group
 		groupMembers, err := listGroupMembers(ctx, g.client, groupName)
 		if err != nil {
@@ -206,7 +197,7 @@ func (g *groupBuilder) Revoke(ctx context.Context, grant *v2.Grant) (annotations
 		}
 
 		groupPos := slices.IndexFunc(groupMembers, func(c client.Members) bool {
-			return c.ID == userId
+			return c.Name == userName
 		})
 		if groupPos < 0 {
 			l.Info(
@@ -224,7 +215,6 @@ func (g *groupBuilder) Revoke(ctx context.Context, grant *v2.Grant) (annotations
 		}
 
 		l.Info("Group membership revoked.",
-			zap.Int64("UserID", int64(userId)),
 			zap.String("User", userName),
 			zap.String("Group", groupName),
 		)

--- a/pkg/connector/org.go
+++ b/pkg/connector/org.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"slices"
-	"strconv"
 	"strings"
 
 	"github.com/conductorone/baton-bitbucket-datacenter/pkg/client"
@@ -202,18 +201,14 @@ func (o *orgBuilder) Grant(ctx context.Context, principal *v2.Resource, entitlem
 
 	switch principal.Id.ResourceType {
 	case resourceTypeUser.Id:
-		userName := principal.DisplayName
-		userId, err := strconv.Atoi(principal.Id.Resource)
-		if err != nil {
-			return nil, err
-		}
+		userName := principal.Id.Resource
 
 		globalUserPermissions, err := listGlobalUserPermissions(ctx, o.client)
 		if err != nil {
 			return nil, err
 		}
 		idx := slices.IndexFunc(globalUserPermissions, func(c client.UsersPermissions) bool {
-			return c.User.ID == userId
+			return c.User.Name == userName
 		})
 		if idx > -1 {
 			userPermission := globalUserPermissions[idx]
@@ -228,7 +223,6 @@ func (o *orgBuilder) Grant(ctx context.Context, principal *v2.Resource, entitlem
 		}
 
 		l.Info("User global permission granted.",
-			zap.Int64("UserID", int64(userId)),
 			zap.String("User", userName),
 			zap.String("Permission", permission),
 		)
@@ -294,17 +288,14 @@ func (o *orgBuilder) Revoke(ctx context.Context, grant *v2.Grant) (annotations.A
 
 	switch principal.Id.ResourceType {
 	case resourceTypeUser.Id:
-		userName := principal.DisplayName
-		userId, err := strconv.Atoi(principal.Id.Resource)
-		if err != nil {
-			return nil, err
-		}
+		userName := principal.Id.Resource
+
 		globalUserPermissions, err := listGlobalUserPermissions(ctx, o.client)
 		if err != nil {
 			return nil, err
 		}
 		idx := slices.IndexFunc(globalUserPermissions, func(c client.UsersPermissions) bool {
-			return c.User.ID == userId
+			return c.User.Name == userName
 		})
 		if idx == -1 {
 			return annotations.New(&v2.GrantAlreadyRevoked{}), nil
@@ -326,7 +317,6 @@ func (o *orgBuilder) Revoke(ctx context.Context, grant *v2.Grant) (annotations.A
 		}
 
 		l.Info("User global permission revoked.",
-			zap.Int64("UserID", int64(userId)),
 			zap.String("User", userName),
 			zap.String("Permission", permission),
 		)

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -17,9 +17,6 @@ func userResource(_ context.Context, user *client.User, parentResourceID *v2.Res
 		displayName = user.Name
 	}
 	if displayName == "" {
-		displayName = user.Slug
-	}
-	if displayName == "" {
 		displayName = user.EmailAddress
 	}
 	firstName, lastName := rs.SplitFullName(displayName)
@@ -45,7 +42,7 @@ func userResource(_ context.Context, user *client.User, parentResourceID *v2.Res
 	userTraits := []rs.UserTraitOption{
 		rs.WithUserProfile(profile),
 		rs.WithStatus(userStatus),
-		rs.WithUserLogin(user.Slug),
+		rs.WithUserLogin(user.Name),
 		rs.WithEmail(user.EmailAddress, true),
 	}
 
@@ -59,7 +56,7 @@ func userResource(_ context.Context, user *client.User, parentResourceID *v2.Res
 	ret, err := rs.NewUserResource(
 		displayName,
 		resourceTypeUser,
-		user.ID,
+		user.Name,
 		userTraits,
 		rs.WithParentResourceID(parentResourceID))
 	if err != nil {


### PR DESCRIPTION
Use username for user resource IDs. Change all the user-related grant/revokes to use the username instead of ID or displayname. The old code just happened to work because in our tests, the display name was the same as the username.
