### PR TITLE
Fix grant expansion for repos.

### DIFF
--- a/pkg/connector/group.go
+++ b/pkg/connector/group.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/conductorone/baton-bitbucket-datacenter/pkg/client"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
@@ -21,6 +22,7 @@ func groupResource(_ context.Context, groupName string, parentResourceId *v2.Res
 	if groupName == "" {
 		return nil, fmt.Errorf("bitbucket(dc)-connector: group name is empty")
 	}
+	groupId := strings.ToLower(groupName)
 	resourceOptions := []rs.ResourceOption{}
 	if parentResourceId != nil {
 		resourceOptions = append(resourceOptions, rs.WithParentResourceID(parentResourceId))
@@ -28,7 +30,7 @@ func groupResource(_ context.Context, groupName string, parentResourceId *v2.Res
 	resource, err := rs.NewGroupResource(
 		groupName,
 		resourceTypeGroup,
-		groupName,
+		groupId,
 		nil,
 		resourceOptions...,
 	)


### PR DESCRIPTION
The Bitbucket Datacenter API lower cases group names in some API responses. Work around this issue by lower-casing the group name for the group resource ID.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved handling of group identifiers by standardizing group names to lowercase during resource creation.

- **Bug Fixes**
	- Enhanced error handling for empty group names and resource creation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->