### PR TITLE
Update connector page title to include parent company name

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Set up a Bitbucket Data Center connector"
+title:"Set up an Atlassian Bitbucket Data Center connector"
 description: "C1 provides identity governance and just-in-time provisioning for Bitbucket Data Center. Integrate your Bitbucket Data Center instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
-og:title: "Set up a Bitbucket Data Center connector"
+og:title:"Set up an Atlassian Bitbucket Data Center connector"
 og:description: "C1 provides identity governance and just-in-time provisioning for Bitbucket Data Center. Integrate your Bitbucket Data Center instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
 sidebarTitle: "Atlassian Bitbucket Data Center"
 ---
@@ -45,7 +45,7 @@ Configuring the connector requires you to pass in credentials generated in Bitbu
     </Step>
 </Steps>
 
-**That's it!** Next, move on to the connector configuration instructions.
+**Done.** Next, move on to the connector configuration instructions.
 
 ## Configure the Bitbucket Data Center connector
 
@@ -176,7 +176,7 @@ spec:
     </Step>
 </Steps>
 
-**That's it!** Your Bitbucket Data Center connector is now pulling access data into C1.
+**Done.** Your Bitbucket Data Center connector is now pulling access data into C1.
 </Tab>
 </Tabs>
 

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -1,7 +1,7 @@
 ---
-title:"Set up an Atlassian Bitbucket Data Center connector"
+title: "Set up an Atlassian Bitbucket Data Center connector"
 description: "C1 provides identity governance and just-in-time provisioning for Bitbucket Data Center. Integrate your Bitbucket Data Center instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
-og:title:"Set up an Atlassian Bitbucket Data Center connector"
+og:title: "Set up an Atlassian Bitbucket Data Center connector"
 og:description: "C1 provides identity governance and just-in-time provisioning for Bitbucket Data Center. Integrate your Bitbucket Data Center instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
 sidebarTitle: "Atlassian Bitbucket Data Center"
 ---


### PR DESCRIPTION
This PR updates the connector page title and og:title to include the parent company name for better discoverability and consistency across connector docs.

Also replaces any remaining instances of `That's it!` with `Done.`