### PR TITLE
docs: update Docker image registry from GHCR to ECR Public

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -155,7 +155,7 @@ spec:
     spec:
       containers:
       - name: baton-bitbucket-datacenter
-        image: ghcr.io/conductorone/baton-bitbucket-datacenter:latest
+        image: public.ecr.aws/conductorone/baton-bitbucket-datacenter:latest
         imagePullPolicy: IfNotPresent
         env:
         - name: BATON_HOST_ID
@@ -179,5 +179,3 @@ spec:
 **Done.** Your Bitbucket Data Center connector is now pulling access data into C1.
 </Tab>
 </Tabs>
-
-


### PR DESCRIPTION
## Summary

Connector images are now published exclusively to ECR Public (`public.ecr.aws/conductorone/`). This PR updates `docs/connector.mdx` accordingly.

**Changes made:**
- Updates Docker image reference from `ghcr.io/conductorone/` to `public.ecr.aws/conductorone/`
- Adds `### Resources` section (download center + GitHub repo links) if missing from the self-hosted setup instructions

_This PR was generated automatically._