### PR TITLE
fix: mark bitbucketdc-password and bitbucketdc-token as isSecret in config_schema

### DIFF
--- a/cmd/baton-bitbucket-datacenter/config.go
+++ b/cmd/baton-bitbucket-datacenter/config.go
@@ -12,6 +12,7 @@ var (
 	BitbucketPassword = field.StringField(
 		"bitbucketdc-password",
 		field.WithDescription("Application password used to connect to the BitBucketDC API."),
+		field.WithIsSecret(true),
 	)
 	BitbucketBaseUrl = field.StringField(
 		"bitbucketdc-baseurl",
@@ -22,6 +23,7 @@ var (
 	BitbucketToken = field.StringField(
 		"bitbucketdc-token",
 		field.WithDescription("HTTP access tokens in Bitbucket Data Center"),
+		field.WithIsSecret(true),
 	)
 	SkipRepos = field.BoolField(
 		"skip-repos",


### PR DESCRIPTION
The `bitbucketdc-password` and `bitbucketdc-token` config fields carry
authentication credentials (application password and HTTP access token) for the
Bitbucket Data Center API, but both were defined as plain `field.StringField`
with no `field.WithIsSecret(true)`, so neither was marked secret in the
connector's config schema. This adds `WithIsSecret(true)` to both. The
`bitbucketdc-username` and `bitbucketdc-baseurl` fields are not credentials and
are correctly left unmarked.

> BREAKING: adding `isSecret: true` to these fields changes how existing
> configurations are stored. Customers with existing connector configurations
> will need to re-enter credentials after this change is deployed.

_Built with stargate._
